### PR TITLE
chore: distinguish build assets per OS in workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Upload assets
         uses: actions/upload-artifact@v4
         with:
-          name: assets
+          name: assets-${{ matrix.os_name }}
           path: assets
 
   release:
@@ -59,7 +59,7 @@ jobs:
       - name: Download assets
         uses: actions/download-artifact@v4
         with:
-          name: assets
+          pattern: assets-*
           path: assets
 
       - name: Release


### PR DESCRIPTION
## Summary
- use OS-specific names for build artifacts
- fetch all matching artifacts in release job

## Testing
- `bash ./check_tags.sh`
- `bash ./check_cron_or_pr.sh`


------
https://chatgpt.com/codex/tasks/task_e_689f9ac65f7c832b92b2a685755ace38