### PR TITLE
ci: allow release job to write contents

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,6 +53,8 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: ${{ secrets.GITHUB_TOKEN != '' }}
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- allow release job to write repository contents so releases can be created

## Testing
- `npx --yes yaml-lint .github/workflows/build.yml`


------
https://chatgpt.com/codex/tasks/task_e_689f9bde5610832ba342c6e17a3f4080